### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include minecraft_model_reader/image/*.*
+recursive-include minecraft_model_reader/resource_packs/java_vanilla_fix/* *.*


### PR DESCRIPTION
Fixes image files not being properly included when being built into/installed as a python package as well as when being included in a PyInstaller build