### PR TITLE
Update pillow version to at least 10.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ zip_safe = False
 include_package_data = True
 python_requires = ~=3.6
 install_requires =
-    Pillow>=7.1
+    Pillow>=10.0.1
     numpy>=1.17
     amulet-nbt~=2.0
     platformdirs~=3.1


### PR DESCRIPTION
This change makes the minimum required Pillow version be 10.0.1 instead of 7.1