### PR TITLE
Fix air rendering

### DIFF
--- a/minecraft_model_reader/api/resource_pack/java/resource_pack_manager.py
+++ b/minecraft_model_reader/api/resource_pack/java/resource_pack_manager.py
@@ -356,7 +356,9 @@ class JavaResourcePackManager(BaseResourcePackManager[JavaResourcePack]):
         }
         transparent = Transparency.Partial
 
-        if java_model.get("textures", {}) and not java_model.get("elements"):
+        if set(java_model.get("textures", {})).difference(
+            {"particle"}
+        ) and not java_model.get("elements"):
             return self.missing_block
 
         for element in java_model.get("elements", {}):


### PR DESCRIPTION
Fixes Amulet-Team/Amulet-Map-Editor#1119

These two lines of code were to display the missing block if the block had textures but no elements which is the case for polygon mesh formats that we don't support. Minecraft Java 1.21.4 added a particle texture which broke this.