### PR TITLE
Handle case when st_mtime is zero

### DIFF
--- a/minecraft_model_reader/api/resource_pack/bedrock/resource_pack_manager.py
+++ b/minecraft_model_reader/api/resource_pack/bedrock/resource_pack_manager.py
@@ -140,8 +140,9 @@ class BedrockResourcePackManager(BaseResourcePackManager):
         else:
             texture_path = self.missing_no
         if (
-            os.stat(texture_path).st_mtime
-            != self._texture_is_transparent.get(texture_path, [0])[0]
+            texture_path not in self._texture_is_transparent
+            or os.stat(texture_path).st_mtime
+            != self._texture_is_transparent[texture_path][0]
         ):
             im: Image.Image = Image.open(texture_path)
             if im.mode == "RGBA":

--- a/minecraft_model_reader/api/resource_pack/java/resource_pack_manager.py
+++ b/minecraft_model_reader/api/resource_pack/java/resource_pack_manager.py
@@ -116,8 +116,9 @@ class JavaResourcePackManager(BaseResourcePackManager[JavaResourcePack]):
                         rel_path = "/".join(rel_path_list)[:-4]
                         self._textures[(namespace, rel_path)] = texture_path
                         if (
-                            os.stat(texture_path).st_mtime
-                            != self._texture_is_transparent.get(texture_path, [0])[0]
+                            texture_path not in self._texture_is_transparent
+                            or os.stat(texture_path).st_mtime
+                            != self._texture_is_transparent[texture_path][0]
                         ):
                             im: Image.Image = Image.open(texture_path)
                             if im.mode == "RGBA":


### PR DESCRIPTION
In some cases st_mtime can be zero.
We still want to populate _texture_is_transparent in these cases.